### PR TITLE
Added compatibility with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required ( VERSION 3.0 )
+cmake_minimum_required( VERSION 3.5...3.15 )
 
 project ( SigFinder )
 

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required ( VERSION 3.0 )
+cmake_minimum_required( VERSION 3.5...3.15 )
 
 project (demo)
 

--- a/sig_finder/CMakeLists.txt
+++ b/sig_finder/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5...3.15)
 project (sig_finder)
 
 # Offer the user the choice of overriding the installation directories


### PR DESCRIPTION
CMake 4 removes support for all CMake versions prior to 3.5:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

This PR adds compatibility with CMake 4.